### PR TITLE
Bundle a wrapper for bindtextdomain(), to be used with LD_PRELOAD

### DIFF
--- a/bindtextdomain-Makefile
+++ b/bindtextdomain-Makefile
@@ -1,0 +1,7 @@
+all:
+	gcc -shared -fPIC bindtextdomain.c -o libbindtextdomain-wrapper.so
+
+install:
+	mkdir -p /app/lib
+	install -m 755 libbindtextdomain-wrapper.so /app/lib
+

--- a/bindtextdomain.c
+++ b/bindtextdomain.c
@@ -1,0 +1,92 @@
+/*
+ * Nasty preload hack to allow message catalogs to be read from the build tree.
+ *
+ * export LD_PRELOAD=/usr/lib/help2man/bindtextdomain.so
+ * export TEXTDOMAIN=program
+ * export LOCALEDIR=${DESTDIR}/usr/share/locale
+ *
+ * Copyright (C) 2012 Free Software Foundation, Inc.
+ *
+ * Copying and distribution of this file, with or without modification,
+ * are permitted in any medium without royalty provided the copyright
+ * notice and this notice are preserved.  This file is offered as-is,
+ * without any warranty.
+ *
+ * Written by Brendan O'Dea <bod@debian.org>
+ */
+
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dlfcn.h>
+
+#define PRELOAD "bindtextdomain.so"
+
+static void die(char const *msg)
+{
+    fprintf(stderr, PRELOAD ": %s\n", msg);
+    exit(1);
+}
+
+static char *e_textdomain = 0;
+static char *e_localedir = 0;
+static char *(*r_textdomain)(char const *) = 0;
+static char *(*r_bindtextdomain)(char const *, char const *) = 0;
+static char *(*r_bind_textdomain_codeset)(char const *, char const *) = 0;
+
+void setup()
+{
+    static int done = 0;
+    if (done++)
+        return;
+
+    if (!(e_textdomain = getenv("TEXTDOMAIN")))
+	die("TEXTDOMAIN not set");
+
+    if (!(e_localedir = getenv("LOCALEDIR")))
+	die("LOCALEDIR not set");
+
+    if (!(r_textdomain = dlsym(RTLD_NEXT, "textdomain")))
+	die("can't find symbol \"textdomain\"");
+
+    if (!(r_bindtextdomain = dlsym(RTLD_NEXT, "bindtextdomain")))
+	die("can't find symbol \"bindtextdomain\"");
+
+    if (!(r_bind_textdomain_codeset = dlsym(RTLD_NEXT,
+    					    "bind_textdomain_codeset")))
+	die("can't find symbol \"bind_textdomain_codeset\"");
+}
+
+char *textdomain(char const *domainname)
+{
+    char *r;
+    setup();
+    r = r_textdomain(domainname);
+    if (domainname && !strcmp(domainname, e_textdomain))
+        r_bindtextdomain(domainname, e_localedir);
+
+    return r;
+}
+
+char *bindtextdomain(char const *domainname, char const *dirname)
+{
+    char const *dir = dirname;
+    setup();
+    if (domainname && !strcmp(domainname, e_textdomain))
+        dir = e_localedir;
+
+    return r_bindtextdomain(domainname, dir);
+}
+
+char *bind_textdomain_codeset(char const *domainname, char const *codeset)
+{
+    char *r;
+    setup();
+    r = r_bind_textdomain_codeset(domainname, codeset);
+    if (domainname && !strcmp(domainname, e_textdomain))
+        r_bindtextdomain(domainname, e_localedir);
+
+    return r;
+}

--- a/org.videolan.VLC.json
+++ b/org.videolan.VLC.json
@@ -867,6 +867,21 @@
           "branch": "stable-1.1"
         }
       ]
+    },
+    {
+      "name": "bindtextdomain-wrapper",
+      "no-autogen": true,
+      "sources": [
+        {
+          "type": "file",
+          "path": "bindtextdomain.c"
+        },
+        {
+          "type": "file",
+          "path": "bindtextdomain-Makefile",
+          "dest-filename": "Makefile"
+        }
+      ]
     }
   ]
 }

--- a/org.videolan.VLC.json
+++ b/org.videolan.VLC.json
@@ -267,7 +267,7 @@
       "sources": [
         {
           "type": "archive",
-          "url": "http://gd.tuwien.ac.at/pub/gnupg/libgcrypt/libgcrypt-1.7.4.tar.bz2",
+          "url": "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.7.4.tar.bz2",
           "sha256": "3b67862e2f4711e25c4ce3cc4b48d52a58a3afdcd1d8c6a57f93a1c0ef03e5c6"
         }
       ]

--- a/vlc.sh
+++ b/vlc.sh
@@ -1,3 +1,9 @@
 #!/bin/sh
 
+# Make sure VLC finds the translations in their right place
+# by using the LD_PRELOAD wrapper for bindtextdomain()
+export LD_PRELOAD=/app/lib/libbindtextdomain-wrapper.so
+export LOCALEDIR=/app/extra/share/locale
+export TEXTDOMAIN=vlc
+
 exec /app/extra/bin/vlc


### PR DESCRIPTION
This will allow us to force VLC find the locale directory under /app/extra
instead of looking into /usr, despite of having been built that way.

https://phabricator.endlessm.com/T15341