### PR TITLE
Update runtime to 3.2 to reduce download size

### DIFF
--- a/org.videolan.VLC.json
+++ b/org.videolan.VLC.json
@@ -1,9 +1,9 @@
 {
   "app-id": "org.videolan.VLC",
   "runtime": "com.endlessm.Platform",
-  "runtime-version": "eos3.1",
+  "runtime-version": "eos3.2",
   "sdk": "com.endlessm.Sdk",
-  "branch": "2.2.4",
+  "branch": "2.2.6",
   "command": "vlc",
   "separate-locales": false,
   "finish-args": [


### PR DESCRIPTION
this also changes the branch to 2.2.6 to reflect the actual version that we're running - if that's not a good idea then kill that change.