### PR TITLE
Update broken VLC related extra-data

### DIFF
--- a/org.videolan.VLC.json
+++ b/org.videolan.VLC.json
@@ -49,11 +49,11 @@
     "--extra-data=libgroupsock1.deb:28c0389cac5c3189cb12a95949dffe84b020f35b1aebf1116ff34eef52530d3b:26318::http://ftp.us.debian.org/debian/pool/main/libl/liblivemedia/libgroupsock1_2014.01.13-1_amd64.deb",
     "--extra-data=libbasicusageenvironment0.deb:b557d596be0e064aeb5678e6ab269c7ede9fd0f5b23ac4e0d110dbcc4457739b:20542::http://ftp.us.debian.org/debian/pool/main/libl/liblivemedia/libbasicusageenvironment0_2014.01.13-1_amd64.deb",
     "--extra-data=libusageenvironment1.deb:dc583daabe815aac08a54d0d62e1a7d40ae1623d68f29ae153ea06c77b3d950c:11460::http://ftp.us.debian.org/debian/pool/main/libl/liblivemedia/libusageenvironment1_2014.01.13-1_amd64.deb",
-    "--extra-data=vlc-data.deb:4e591ddd5f001b0ca7e48d4fd84a3ab19bee5d212e3a519ca146af31c3686038:6034156::http://ftp.us.debian.org/debian/pool/main/v/vlc/vlc-data_2.2.6-1~deb8u1_all.deb",
-    "--extra-data=libvlccore8.deb:c144a636a0c8ab51925b548dc8035cdd33c9856051b9a8947d7a3de5973d7602:391760::http://ftp.us.debian.org/debian/pool/main/v/vlc/libvlccore8_2.2.6-1~deb8u1_amd64.deb",
-    "--extra-data=libvlc5.deb:bfc1467b89b302a82562a7c1c60b6d047a1ea1a5dd226b5caf2e3a05f475d380:47322::http://ftp.us.debian.org/debian/pool/main/v/vlc/libvlc5_2.2.6-1~deb8u1_amd64.deb",
-    "--extra-data=vlc-nox.deb:f67b4ad6249c4cf1b6b70b21d08b208d0bc8711e08bf0d33d96bbd2d36907a24:2530164::http://ftp.us.debian.org/debian/pool/main/v/vlc/vlc-nox_2.2.6-1~deb8u1_amd64.deb",
-    "--extra-data=vlc.deb:14504bebeb46fc58c2bab340e449d6c5aba10b0116962572edfe7e90b963597a:1501962::http://ftp.us.debian.org/debian/pool/main/v/vlc/vlc_2.2.6-1~deb8u1_amd64.deb"
+    "--extra-data=vlc-data.deb:ee839f2b1259de5a16ff2300603ff28cc7106935691a76829f609a117ab48d14:433766::http://ftp.us.debian.org/debian/pool/main/v/vlc/vlc-data_2.2.7-1~deb9u1_all.deb",
+    "--extra-data=libvlccore8.deb:1cd48fc35820e5177399481e8acf169bae097c0aeeea0c43eb621387a8d72ea0:505728::http://ftp.us.debian.org/debian/pool/main/v/vlc/libvlccore8_2.2.7-1~deb9u1_amd64.deb",
+    "--extra-data=libvlc5.deb:1638cd6e22dd304c1a12ea89b2ee2a8a02af15307dd9aa6c7f8d025014140ce8:164520::http://ftp.us.debian.org/debian/pool/main/v/vlc/libvlc5_2.2.7-1~deb9u1_amd64.deb",
+    "--extra-data=vlc-nox.deb:c936dc07b429bcc1f4323a176cfce21b09000323fce71dccbad326293d2d1436:118890::http://ftp.us.debian.org/debian/pool/main/v/vlc/vlc-nox_2.2.7-1~deb9u1_amd64.deb",
+    "--extra-data=vlc.deb:25656253a07992aef7d233e30fa33f99afda333ffc131fa0c0e6ab009622aca8:135522::http://ftp.us.debian.org/debian/pool/main/v/vlc/vlc_2.2.7-1~deb9u1_amd64.deb"
   ],
   "modules": [
     {


### PR DESCRIPTION
The packages that were broken this time are:
  * vlc-data;
  * libvlccore8
  * libvlc5
  * vlc-nox
  * vlc

https://phabricator.endlessm.com/T20400